### PR TITLE
SWUTILS-915: Added --version and -v cmdline options

### DIFF
--- a/sfreport.pl
+++ b/sfreport.pl
@@ -3022,7 +3022,14 @@ sub check_x3_debug_info {
 
 # Establish output stream.
 my $minimal = '';
-GetOptions("m" => \$minimal);
+my $version = '';
+GetOptions("m" => \$minimal,
+           "version|v" => \$version);
+
+if ($version) {
+    STDERR->print("AMD Solarflare system report (version $VERSION)\n");
+    exit 0;
+}
 
 if ($minimal) {
     $out_format = format_minimal;
@@ -3034,6 +3041,10 @@ if ($#ARGV >= 0) {
 } else {
     $out_path = POSIX::strftime('sfreport-%Y-%m-%d-%H-%M-%S.html',
 				localtime);
+}
+
+if ($out_path ne '-') {
+    STDERR->print("AMD Solarflare system report (version $VERSION)\n");
 }
 
 if ($out_format != format_minimal) {


### PR DESCRIPTION
If run with either --version or -v will now output the version information before exiting.
Potentially worth adding a usage option (--help -h) if more options are added to script.