### PR TITLE
SWUTILS-915: Added -v and --version options to print version information

### DIFF
--- a/sfreport.pl
+++ b/sfreport.pl
@@ -3022,7 +3022,14 @@ sub check_x3_debug_info {
 
 # Establish output stream.
 my $minimal = '';
-GetOptions("m" => \$minimal);
+my $version = '';
+GetOptions("m" => \$minimal,
+           "version|v" => \$version);
+
+if ($version) {
+    STDERR->print("AMD Solarflare system report (version $VERSION)\n");
+    exit 0;
+}
 
 if ($minimal) {
     $out_format = format_minimal;
@@ -3034,6 +3041,10 @@ if ($#ARGV >= 0) {
 } else {
     $out_path = 'sfreport-'.$hostname.POSIX::strftime('-%Y-%m-%d-%H-%M-%S.html',
 				localtime);
+}
+
+if ($out_path ne '-') {
+    STDERR->print("AMD Solarflare system report (version $VERSION)\n");
 }
 
 if ($out_format != format_minimal) {


### PR DESCRIPTION
With this patch sfreport can know be run with either -v or --version to print out the version information and exit:
``` 
$perl ./sfreport.pl -v
AMD Solarflare system report (version 4.16.0) 
```
```
$ perl ./sfreport.pl --version
AMD Solarflare system report (version 4.16.0)
```

Also when sfreport is run without printing to stdout/stderr. It will now print out the version information along with where the file is written.

```
$ sudo perl sfreport.pl
AMD Solarflare system report (version 4.16.0)
Finished writing report to sfreport-<hostname>-2024-02-20-14-12-24.html
```

This should help quickly check version of sfreport customers are running when we are working on a call with them.