### PR TITLE
SWUTILS-805: Fix MemFree and MemAvailable labels

### DIFF
--- a/sfreport.pl
+++ b/sfreport.pl
@@ -902,6 +902,7 @@ sub print_system_summary {
       
 	    $meminfo_file->close();
 	    push @attributes, ('Total Physical Memory',
+			       'Free Physical Memory',
 			       'Available Physical Memory',
 			       'Total Virtual Memory',
 			       'Available Virtual Memory',
@@ -909,6 +910,7 @@ sub print_system_summary {
 	    push @value, map(sprintf('%d MB', $_ / 1024),
 			     $meminfo{MemTotal},
 			     $meminfo{MemFree},
+			     $meminfo{MemAvailable},
 			     # Count all physical memory and swap
 			     # minus kernel allocations as virtual
 			     # memory.  Assume kernel code and static


### PR DESCRIPTION
We have been labeling `/proc/meminfo`'s `MemFree` as `Available Physical Memory`. This is techincally incorrect as there is `MemAvailable` to describe this.
This patch now labels `MemFree` as `Free Physical Memory` and `MemAvaliable` is used for `Available Physical Memory`.