### PR TITLE
SWUTILS-930: Add "ethtool --show-fec" output to sfreport

### DIFF
--- a/sfreport.pl
+++ b/sfreport.pl
@@ -2168,7 +2168,7 @@ tabulate('TCP (IPv4) settings',
     for my $iface_name (sort keys(%iface_names)) {
 	# ethtool's default output is difficult to parse so
 	# include it (almost) verbatim.
-	my $ethtool_output;
+	my %ethtool_output;
 	for my $option ('', '-a', '-c', '-k', '-g', '-m', '-T', '-n', '--show-fec') {
 	    if (my $ethtool_file =
 		new FileHandle("ethtool $option '$iface_name' 2>/dev/null |")) {
@@ -2181,13 +2181,16 @@ tabulate('TCP (IPv4) settings',
 		    } else {
 			s/^\s*/        /gm;     # indent others consistently
 		    }
-		    $ethtool_output .= $_;
+		    $ethtool_output{$option} .= $_;
 		}
 	    }
 	}
-	if (defined($ethtool_output)) {
+	if (defined(keys %ethtool_output)) {
 	    print_heading("Ethernet settings for $iface_name (ethtool)", 'ethset_'.$iface_name);
-	    print_preformatted($ethtool_output);
+            for(sort(keys %ethtool_output)) {
+                print_heading("ethtool $_ $iface_name");
+                print_preformatted($ethtool_output{$_});
+            }
       print_footer('ethset_'.$iface_name);
 	}
     }

--- a/sfreport.pl
+++ b/sfreport.pl
@@ -2169,7 +2169,7 @@ tabulate('TCP (IPv4) settings',
 	# ethtool's default output is difficult to parse so
 	# include it (almost) verbatim.
 	my $ethtool_output;
-	for my $option ('', '-a', '-c', '-k', '-g', '-m', '-T', '-n') {
+	for my $option ('', '-a', '-c', '-k', '-g', '-m', '-T', '-n', '--show-fec') {
 	    if (my $ethtool_file =
 		new FileHandle("ethtool $option '$iface_name' 2>/dev/null |")) {
 		while (<$ethtool_file>) {


### PR DESCRIPTION
Added the '--show-fec' option to the list of ethtool commands ran as part of sfreport.
Additional commit was added to add headings for the individual ethtool commands to make it easier to search for specific ethtool command on the interfaces. But this commit is optional and potentially can be removed (would revert to one big block of ethtool output).

```
$sudo perl sfreport.pl
AMD Solarflare system report (version 4.16.0)
Finished writing report to sfreport-dellr630ag-2024-03-26-14-21-11.html
```

Below is a recreation of the sfreport html (from above) output using github markdown (headings etc...)
### Ethernet settings for enp130s0f0 (ethtool) Hide...
### ethtool enp130s0f0
Settings
        Supported ports: [ FIBRE ]
        Supported link modes:   1000baseT/Full
        25000baseCR/Full
        25000baseSR/Full
        1000baseX/Full
        10000baseCR/Full
        10000baseSR/Full
        10000baseLR/Full
        Supported pause frame use: Symmetric Receive-only
        Supports auto-negotiation: Yes
        Supported FEC modes: None	 RS	 BASER
        Advertised link modes:  1000baseT/Full
        25000baseCR/Full
        25000baseSR/Full
        1000baseX/Full
        10000baseCR/Full
        10000baseSR/Full
        10000baseLR/Full
        Advertised pause frame use: Symmetric
        Advertised auto-negotiation: Yes
        Advertised FEC modes: None	 RS	 BASER
        Link partner advertised link modes:  Not reported
        Link partner advertised pause frame use: No
        Link partner advertised auto-negotiation: No
        Link partner advertised FEC modes: None
        Speed: 10000Mb/s
        Duplex: Full
        Auto-negotiation: on
        Port: Direct Attach Copper
        PHYAD: 255
        Transceiver: internal
        Supports Wake-on: d
        Wake-on: d
        Current message level: 0x000020f7 (8439)
        drv probe link ifdown ifup rx_err tx_err hw
        Link detected: yes
### ethtool --show-fec enp130s0f0
FEC parameters
        Configured FEC encodings: Auto
        Active FEC encoding: Off
### ethtool -T enp130s0f0
Time stamping parameters
        Capabilities:
        hardware-transmit
        software-transmit
        hardware-receive
        software-receive
        software-system-clock
        hardware-legacy-clock
        hardware-raw-clock
        PTP Hardware Clock: 1
        Hardware Transmit Timestamp Modes:
        off
        on
        Hardware Receive Filter Modes:
        none
        all
### ethtool -a enp130s0f0
Pause parameters
        Autonegotiate:	on
        RX:		on
        TX:		on
        RX negotiated: off
        TX negotiated: off
### ethtool -c enp130s0f0
Coalesce parameters
        Adaptive RX: on  TX: n/a
        stats-block-usecs: 1000000
        sample-interval: n/a
        pkt-rate-low: n/a
        pkt-rate-high: n/a
        rx-usecs: 60
        rx-frames: n/a
        rx-usecs-irq: 60
        rx-frames-irq: n/a
        tx-usecs: 60
        tx-frames: n/a
        tx-usecs-irq: 60
        tx-frames-irq: n/a
        rx-usecs-low: n/a
        rx-frame-low: n/a
        tx-usecs-low: n/a
        tx-frame-low: n/a
        rx-usecs-high: n/a
        rx-frame-high: n/a
        tx-usecs-high: n/a
        tx-frame-high: n/a
        CQE mode RX: n/a  TX: n/a
### ethtool -g enp130s0f0
Ring parameters
        Pre-set maximums:
        RX:		4096
        RX Mini:	n/a
        RX Jumbo:	n/a
        TX:		2048
        Current hardware settings:
        RX:		1024
        RX Mini:	n/a
        RX Jumbo:	n/a
        TX:		1024
### ethtool -k enp130s0f0
Features
        rx-checksumming: on
        tx-checksumming: on
        tx-checksum-ipv4: on
        tx-checksum-ip-generic: off [fixed]
        tx-checksum-ipv6: on
        tx-checksum-fcoe-crc: off [fixed]
        tx-checksum-sctp: off [fixed]
        scatter-gather: on
        tx-scatter-gather: on
        tx-scatter-gather-fraglist: off [fixed]
        tcp-segmentation-offload: on
        tx-tcp-segmentation: on
        tx-tcp-ecn-segmentation: on
        tx-tcp-mangleid-segmentation: off
        tx-tcp6-segmentation: on
        generic-segmentation-offload: on
        generic-receive-offload: on
        large-receive-offload: off
        rx-vlan-offload: off [fixed]
        tx-vlan-offload: on [fixed]
        ntuple-filters: on
        receive-hashing: on
        highdma: on [fixed]
        rx-vlan-filter: off
        vlan-challenged: off [fixed]
        tx-lockless: off [fixed]
        netns-local: off [fixed]
        tx-gso-robust: off [fixed]
        tx-fcoe-segmentation: off [fixed]
        tx-gre-segmentation: off [fixed]
        tx-gre-csum-segmentation: off [fixed]
        tx-ipxip4-segmentation: off [fixed]
        tx-ipxip6-segmentation: off [fixed]
        tx-udp_tnl-segmentation: off [fixed]
        tx-udp_tnl-csum-segmentation: off [fixed]
        tx-gso-partial: off [fixed]
        tx-tunnel-remcsum-segmentation: off [fixed]
        tx-sctp-segmentation: off [fixed]
        tx-esp-segmentation: off [fixed]
        tx-udp-segmentation: off [fixed]
        tx-gso-list: off [fixed]
        fcoe-mtu: off [fixed]
        tx-nocache-copy: off
        loopback: off [fixed]
        rx-fcs: off
        rx-all: off
        tx-vlan-stag-hw-insert: off [fixed]
        rx-vlan-stag-hw-parse: off [fixed]
        rx-vlan-stag-filter: off [fixed]
        l2-fwd-offload: off [fixed]
        hw-tc-offload: off [fixed]
        esp-hw-offload: off [fixed]
        esp-tx-csum-hw-offload: off [fixed]
        rx-udp_tunnel-port-offload: off [fixed]
        tls-hw-tx-offload: off [fixed]
        tls-hw-rx-offload: off [fixed]
        rx-gro-hw: off [fixed]
        tls-hw-record: off [fixed]
        rx-gro-list: off
        macsec-hw-offload: off [fixed]
        rx-udp-gro-forwarding: off
        hsr-tag-ins-offload: off [fixed]
        hsr-tag-rm-offload: off [fixed]
        hsr-fwd-offload: off [fixed]
        hsr-dup-offload: off [fixed]
### ethtool -m enp130s0f0
Identifier                                : 0x03 (SFP)
        Extended identifier                       : 0x04 (GBIC/SFP defined by 2-wire interface ID)
        Connector                                 : 0x23 (No separable connector)
        Transceiver codes                         : 0x01 0x00 0x00 0x00 0x00 0x84 0x00 0x00 0x0d
        Transceiver type                          : Infiniband: 1X Copper Passive
        Transceiver type                          : FC: Electrical intra-enclosure (EL)
        Transceiver type                          : Passive Cable
        Transceiver type                          : Extended: 25G Base-CR CA-N
        Encoding                                  : 0x06 (64B/66B)
        BR, Nominal                               : 25750MBd
        Rate identifier                           : 0x00 (unspecified)
        Length (SMF,km)                           : 0km
        Length (SMF)                              : 0m
        Length (50um)                             : 0m
        Length (62.5um)                           : 0m
        Length (Copper)                           : 1m
        Length (OM3)                              : 0m
        Passive Cu cmplnce.                       : 0x03 (unknown) [SFF-8472 rev10.4 only]
        Vendor name                               : Amphenol
        Vendor OUI                                : 78:a7:14
        Vendor PN                                 : NDCCGF-C101
        Vendor rev                                : A
        Option values                             : 0x00 0x00
        BR margin, max                            : 0%
        BR margin, min                            : 0%
        Vendor SN                                 : APF18331012LDN
        Date code                                 : 180824
### ethtool -n enp130s0f0
4 RX rings available
        Total 0 rules
