### PR TITLE
SWUTILS-934: Add X3 NICs to collected sensor data

### DIFF
--- a/sfreport.pl
+++ b/sfreport.pl
@@ -1805,11 +1805,12 @@ sub print_device_status {
 	    my $sensor_values;
 
 	    # Check whether this is a grandchild of a device handled
-	    # by sfc (the I2C adapter is a child of the PCI device and
-	    # the hardware monitor is a child of I2C adapter).
+	    # by sfc or xilinx_efct (the I2C adapter is a child of the PCI
+            # device and the hardware monitor is a child of I2C adapter).
 	    my $grandparent_driver = readlink("$device_dir/driver");
 	    next unless defined($grandparent_driver)
-		&& $grandparent_driver =~ m|/sfc$|;
+		&& ($grandparent_driver =~ m|/sfc$| ||
+                  $grandparent_driver =~ m|/xilinx_efct$|);
 
 	    # Use last three components of the device path as its address.
 	    # That should be the PCI device's address, the I2C adapter


### PR DESCRIPTION
Previously the sensors output was filtered on only the sfc driver. However, X3 uses the xilinx_efct driver. This small change enables capture of sensor output for devices running the xilinx_efct driver as well.


Testing done and original bug output can be found on internal JIRA.