### PR TITLE
SWUTILS-944: Detect if onload is installed via RPM or deb

### DIFF
--- a/sfreport.pl
+++ b/sfreport.pl
@@ -22,8 +22,9 @@ use Getopt::Long;
 # AMD Solarflare device/driver identifiers.
 use constant driver_name_re => 'sfc\w*|onload|xilinx_efct';
 use constant rpm_name_prefixes =>
-    'kernel-module-sfc-', 'kmod-solarflare-sfc-', 'sfc-dkms', 'sfutils', 'openonload', 'solar_capture', 'sfptp', 'kernel-module-xilinx-efct';
-use constant deb_name_prefixes => 'sfc-modules-', 'xilinx-efct';
+    'kernel-module-sfc-', 'kmod-solarflare-sfc-', 'sfc-dkms', 'sfutils', 'onload', 'openonload', 'enterpriseonload', 'solar_capture', 'sfptp',
+    'kernel-module-xilinx-efct', 'tcpdirect';
+use constant deb_name_prefixes => 'sfc-modules-', 'xilinx-efct', 'onload', 'enterpriseonload', 'tcpdirect';
 use constant EFX_VENDID_SFC => 0x1924;
 use constant EFX_VENDID_XILINX => 0x10ee;
 


### PR DESCRIPTION
Example output with EOL deb
![image](https://github.com/user-attachments/assets/662f6b74-b2f0-4846-93e3-fd7d017acf66)
Example output with Onload RPM:
![image](https://github.com/user-attachments/assets/80b92289-1d6d-4016-8cdd-3e900dd015f0)
Note that individual entries for 'onload' & 'enterpriseonload' are required.