### PR TITLE
SWUTILS-956: Reduce noise of missing sfutils warning

### DIFF
--- a/sfreport.pl
+++ b/sfreport.pl
@@ -634,9 +634,8 @@ sub get_sfc_drvinfo {
 		$sfc_drvinfo{$iface_name} = $drvinfo;
 	    }
         if ($drvinfo->driver eq 'sfc' && !(my $test = new FileHandle("sfupdate 2>&1 |")) && !($sfc_present)) {
-            STDERR->print("WARNING: Unable to run sfutils (sfkey, sfboot) commands while sfc driver is loaded.\n"
-	                    ."Please make sure the Solarflare Linux Utilities package is installed.\n"
-                        ."NIC configuration (sfboot) and licensing information (sfkey) are unavailable.\n");
+            STDERR->print("INFO: Unable to run sfutils (sfkey, sfboot) commands while sfc driver is loaded. "
+                        ."X2xxx and 8xxx series NIC configuration and licensing information are unavailable.\n");
             $sfc_present = 1;
 	    }
 	}


### PR DESCRIPTION
Not having sfutils installed while sfc driver is loaded is not necessarily a problem since not all sfc driver products will use X4.