### PR TITLE
SWUTILS-957: Added nvlog and ramlog output for SFC

### DIFF
--- a/sfreport.pl
+++ b/sfreport.pl
@@ -2252,13 +2252,16 @@ tabulate('TCP (IPv4) settings',
 	    print_heading("Version information for $iface_name (devlink dev info pci/$bus_info)");
 	    print_preformatted($devlink_file);
 	}
-      my @health_diagnose_options = ('nvcfg-active', 'nvcfg-next', 'nvcfg-stored');
-      foreach my $option (@health_diagnose_options) {
-        if (my $devlink_file =`devlink health diagnose pci/$bus_info reporter $option 2>/dev/null`) {
-	      print_heading("Config for $iface_name (devlink health diagnose pci/$bus_info reporter $option)");
-	      print_preformatted($devlink_file);
-	    }
-      }
+        my @health_diagnose_options = ('nvcfg-active', 'nvcfg-next','nvcfg-stored', 'nvlog', 'ramlog');
+        foreach my $option (@health_diagnose_options) {
+            if (my $devlink_file =`devlink health diagnose pci/$bus_info reporter $option 2>/dev/null`) {
+                my $hide = ($option eq 'nvlog'|| $option eq 'ramlog');
+                print_heading("$option  for $iface_name (devlink health diagnose pci/$bus_info reporter $option)", $hide ? "devlink_health_$iface_name\_$option" : undef, $hide);
+                print_preformatted($devlink_file);
+                next unless $hide;
+                print_footer("devlink_health_$iface_name\_$option");
+            }
+        }
     }
 
     #Collect all devlink params for all PCI devices into hash with parameter


### PR DESCRIPTION
In later drivers devlink health can be used for acquiring the nvlog and ramlog from supported cards. This is useful to collect from customers running drivers with support.

The outputs can be quite long so I have hidden them by default but here is an example output:
<img width="1747" height="519" alt="{6387C0E3-B1CE-4190-99EE-05DA638E1752}" src="https://github.com/user-attachments/assets/8db6cfda-9dde-4145-9ba3-e5ee5026dd32" />

These are quite an expensive call to the NICs so you wouldn't want to run this when NICs are under load but we generally recommend the customers run sfreport outside of production hours anyway.
