### PR TITLE
SWUTILS-961: Suppress some no-perms errors

### DIFF
--- a/sfreport.pl
+++ b/sfreport.pl
@@ -1627,7 +1627,7 @@ sub print_device_status {
   
   print_heading("PCI configuration", "pci_config", 'hide');
      
-    if (my $pcieslot_file = `dmidecode -t slot |grep -b10 'PCI Express' 2>/dev/null`) {
+    if (my $pcieslot_file = `dmidecode -t slot 2>/dev/null | grep -b10 'PCI Express'`) {
         print_heading('PCIe slots info ');
         print_preformatted($pcieslot_file);
     }
@@ -2008,7 +2008,7 @@ sub print_device_status {
         $_ = `dmesg -dxT 2>/dev/null`; 
         if ($?!=0) {
             $dmesg_file->close();
-            $dmesg_file = new FileHandle('dmesg |');
+            $dmesg_file = new FileHandle('dmesg 2>/dev/null |');
         }
 	print_heading("Recent kernel messages about AMD Solarflare adapters"
 		      ." and drivers", "dmesg");


### PR DESCRIPTION
Typically, we rely on our "non-root warning" to inform the user that their sfreport doesn't have full perms.

Before when running as non-root on Ubu 25.04:
```
$  perl ./sfreport.pl ./sfreport.html
AMD Solarflare system report (version 4.16.1)
WARNING: This script will not provide a full report
unless you run it as root.
/sys/firmware/dmi/tables/smbios_entry_point: Permission denied
Can't read memory from /dev/mem
dmesg: read kernel buffer failed: Operation not permitted
Finished writing report to sfreport.html
```
After:
```
$  perl ./sfreport.pl ./sfreport.html
AMD Solarflare system report (version 4.16.1)
WARNING: This script will not provide a full report
unless you run it as root.
Finished writing report to sfreport.html
```