### PR TITLE
SWUTILS-901: Avoid regex on uninitialized value

### DIFF
--- a/sfreport.pl
+++ b/sfreport.pl
@@ -308,6 +308,7 @@ sub pairs {
 
 sub html_encode {
     my $result = shift;
+    return '' unless defined $result;
     $result =~ s/([\&<\'\"])/'&#'.ord($1).';'/eg;
     return $result;
 }


### PR DESCRIPTION
Some users report:
```
Use of uninitialized value $result in substitution (s///) at /home/sfreport.pl line 299.
Use of uninitialized value $_[0] in print at /usr/lib64/perl5/IO/Handle.pm line 420.
```
This is artificially reproduced when calling `print_text` sub on a an uninitialized value. We were unable to determine what command resulted in this being the case in the field, but this patch makes sfreport more robust. 