### PR TITLE
SWUTILS-975: add full version of string for RPM packages

### DIFF
--- a/sfreport.pl
+++ b/sfreport.pl
@@ -1816,26 +1816,26 @@ sub print_device_status {
     # not installed, so we must filter by status.
     my @packages;
     for (['RPM', [rpm_name_prefixes],
-	  "rpm -qa --queryformat '%{Name} %{Version} - - installed\\n'"],
+	  "rpm -qa --queryformat '%{Name} %{Version}-%{Release} %{Arch} - - installed\\n'"],
 	 ['deb', [deb_name_prefixes],
 	  join(' ',
-	       "dpkg-query -W -f '\${Package} \${Version} \${Status}\\n'",
+	       "dpkg-query -W -f '\${Package} \${Version} \${Architecture} \${Status}\\n'",
 	       map({"'$_*'"} deb_name_prefixes))]) {
 	my ($type, $prefixes, $command) = @$_;
 	if (my $query_file = new FileHandle("$command 2>/dev/null |")) {
 	    while (<$query_file>) {
 		chomp;
-		my ($name, $version, undef, undef, $status) = split(/ /);
+		my ($name, $version, $architecture, undef, undef, $status) = split(/ /);
 		if (grep({startswith($name, $_)} @$prefixes) &&
 		    $status eq 'installed') {
-		    push @packages, [$type, $name, $version];
+		    push @packages, [$type, $name, $version, $architecture];
 		}
 	    }
 	}
     }
     tabulate("AMD Solarflare software packages installed",
 	     undef,
-	     ['type', 'name', 'version'],
+	     ['type', 'name', 'version', 'architecture'],
 	     \@packages);
 
     # Onload kernel modules and shared libraries are not currently


### PR DESCRIPTION
RPM version printed in the sfreport can be enhanced to include Release and Architecture. It'll help with more efficient debugging.

Before:
<img width="588" height="178" alt="image" src="https://github.com/user-attachments/assets/38fe77a5-10a6-4597-be70-6bc66494d2ea" />

After:
<img width="575" height="171" alt="image" src="https://github.com/user-attachments/assets/611e6012-7cb9-42d5-ae10-71831e9b8cf5" />

