### PR TITLE
SWUTILS-976: Add ethtool -i output to ethtool section

### DIFF
--- a/sfreport.pl
+++ b/sfreport.pl
@@ -2404,7 +2404,8 @@ tabulate('TCP (IPv4) settings',
 	# ethtool's default output is difficult to parse so
 	# include it (almost) verbatim.
 	my %ethtool_output;
-	for my $option ('', '-a', '-c', '-k', '-g', '-m', '-T', '-n', '--show-fec') {
+	my @ethtool_options = ('', '-a', '-c', '-k', '-g', '-m', '-T', '-n', '-i', '--show-fec');
+	for my $option (@ethtool_options) {
 	    if (my $ethtool_file =
 		new FileHandle("ethtool $option '$iface_name' 2>/dev/null |")) {
 		while (<$ethtool_file>) {


### PR DESCRIPTION
Add `ethtool -i` output to the ethtool section in sfreport. Although driver information is already reported under **Network interfaces for AMD Solarflare adapters**, having `ethtool -i` alongside the other ethtool outputs in **Ethernet settings for <interface> (ethtool)** makes debugging more practical and keeps related interface information together.

After the addition:

<img width="425" height="558" alt="image" src="https://github.com/user-attachments/assets/f3cd365b-9199-4a4f-91c9-5fd35755f281" />

